### PR TITLE
wait for grafana with entertainment

### DIFF
--- a/deploy_prometheus.sh
+++ b/deploy_prometheus.sh
@@ -55,7 +55,14 @@ EOF
 
 docker stack deploy -c prometheus.yml prometheus
 
-sleep 30
+count=0
+limit=60
+int=5
+while ! curl -m 1 -ks http://app.dockr.life:3000/api/health; do
+    echo waiting for grafana to come up: ${count}/${limit} seconds
+    sleep $int
+    count=$(($count+$int))
+done
 
 echo -n " confgiuring grafana through the api "
 curl -skX POST  http://admin:Pa22word@app.dockr.life:3000/api/datasources -H 'Content-Type: application/json' -d "{ \"name\": \"prometheus\",\"type\": \"prometheus\",\"Access\": \"proxy\",\"url\": \"http://prometheus:9090\",\"basicAuth\": false }" > /dev/null 2>&1


### PR DESCRIPTION
poll grafana health endpoint every five seconds for up to 60 seconds


```
...
Creating service prometheus_exporter
waiting for grafana to come up: 0/60 seconds
waiting for grafana to come up: 5/60 seconds
waiting for grafana to come up: 10/60 seconds
waiting for grafana to come up: 15/60 seconds
waiting for grafana to come up: 20/60 seconds
...
```