### PR TITLE
Added constraints to global services

### DIFF
--- a/swarm/prometheus.yml
+++ b/swarm/prometheus.yml
@@ -15,6 +15,9 @@ services:
               mode: host
         deploy:
             mode: global
+            placement:
+                constraints:
+                - node.platform.os == linux
 
     cadvisor:
         image: "google/cadvisor:v0.30.2"
@@ -30,6 +33,9 @@ services:
               mode: host
         deploy:
             mode: global
+            placement:
+                constraints:
+                - node.platform.os == linux
 
     prometheus:
         image: "prom/prometheus:v2.3.1"


### PR DESCRIPTION
Global services are currently attempting to schedule Linux containers onto Windows nodes. Added constraint allows the Global services to succeed