### PR TITLE
Make use of a generic domain

### DIFF
--- a/k8s/prometheus.yml
+++ b/k8s/prometheus.yml
@@ -645,7 +645,7 @@ data:
         module: [http_2xx]
       static_configs:
         - targets:
-          - http://www.hanover.com   
+          - http://www.example.com   
       relabel_configs:
         - source_labels: [__address__]
           target_label: __param_target


### PR DESCRIPTION
A specific domain was used in the yml file. I've modified it to use a generic domain name instead. 